### PR TITLE
Added listener to new page-title-action target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/js/rss_post_aggregation.js
+++ b/assets/js/rss_post_aggregation.js
@@ -1,5 +1,5 @@
 /**
- * RSS Post Aggregator - v0.1.0 - 2017-06-19
+ * RSS Post Aggregator - v0.1.0 - 2017-06-20
  * http://webdevstudios.com
  *
  * Copyright (c) 2017;
@@ -408,7 +408,7 @@ window.RSS_Post_Aggregation = (function(window, document, $, undefined){
 	app.init = function() {
 		log( app );
 		var hrefSelector = '[href="post-new.php?post_type='+ l10n.cpt +'"]';
-		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated
+		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated Class add-new-h2 removed in WP 4.3
 		app.$( '.page-title-action, ' + hrefSelector ).on( 'click', app.openModal );
 
 		log( 'l10n', l10n );

--- a/assets/js/rss_post_aggregation.js
+++ b/assets/js/rss_post_aggregation.js
@@ -1,8 +1,8 @@
 /**
- * RSS Post Aggregator - v0.1.0 - 2014-09-08
+ * RSS Post Aggregator - v0.1.0 - 2017-06-19
  * http://webdevstudios.com
  *
- * Copyright (c) 2014;
+ * Copyright (c) 2017;
  * Licensed GPLv2+
  */
 /*jslint browser: true */
@@ -407,7 +407,9 @@ window.RSS_Post_Aggregation = (function(window, document, $, undefined){
 
 	app.init = function() {
 		log( app );
-		app.$( '.add-new-h2, [href="post-new.php?post_type='+ l10n.cpt +'"]' ).on( 'click', app.openModal );
+		var hrefSelector = '[href="post-new.php?post_type='+ l10n.cpt +'"]';
+		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated
+		app.$( '.page-title-action, ' + hrefSelector ).on( 'click', app.openModal );
 
 		log( 'l10n', l10n );
 		var feeds = _.toArray( l10n.feeds );

--- a/assets/js/src/rss_post_aggregation.js
+++ b/assets/js/src/rss_post_aggregation.js
@@ -408,7 +408,9 @@ window.RSS_Post_Aggregation = (function(window, document, $, undefined){
 
 	app.init = function() {
 		log( app );
-		app.$( '.add-new-h2, [href="post-new.php?post_type='+ l10n.cpt +'"]' ).on( 'click', app.openModal );
+		var hrefSelector = '[href="post-new.php?post_type='+ l10n.cpt +'"]';
+		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated
+		app.$( '.page-title-action, ' + hrefSelector ).on( 'click', app.openModal );
 
 		log( 'l10n', l10n );
 		var feeds = _.toArray( l10n.feeds );

--- a/assets/js/src/rss_post_aggregation.js
+++ b/assets/js/src/rss_post_aggregation.js
@@ -409,7 +409,7 @@ window.RSS_Post_Aggregation = (function(window, document, $, undefined){
 	app.init = function() {
 		log( app );
 		var hrefSelector = '[href="post-new.php?post_type='+ l10n.cpt +'"]';
-		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated
+		app.$( '.add-new-h2, ' + hrefSelector ).on( 'click', app.openModal ); // @deprecated Class add-new-h2 removed in WP 4.3
 		app.$( '.page-title-action, ' + hrefSelector ).on( 'click', app.openModal );
 
 		log( 'l10n', l10n );


### PR DESCRIPTION
The class 'h2-add-new' on the action near the page title was deprecated in favor of 'page-title-action' sometime in WP. Will now listed to both with a comment that the old style is deprecated.

Fixes #6 